### PR TITLE
Fix K8s API server connectivity for IPv6

### DIFF
--- a/charts/rustrial-aws-eks-iam-auth-controller/templates/deployment.yaml
+++ b/charts/rustrial-aws-eks-iam-auth-controller/templates/deployment.yaml
@@ -33,7 +33,11 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           env:
-            {{- toYaml .Values.env | nindent 12 }}
+            - name: RUST_LOG
+              value: debug
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/rustrial-aws-eks-iam-auth-controller/templates/deployment.yaml
+++ b/charts/rustrial-aws-eks-iam-auth-controller/templates/deployment.yaml
@@ -33,8 +33,6 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           env:
-            - name: RUST_LOG
-              value: debug
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/rustrial-aws-eks-iam-auth-controller/templates/deployment.yaml
+++ b/charts/rustrial-aws-eks-iam-auth-controller/templates/deployment.yaml
@@ -33,8 +33,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           env:
-            - name: RUST_LOG
-              value: debug
+            {{- toYaml .Values.env | nindent 12 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/rustrial-aws-eks-iam-auth-controller/values.yaml
+++ b/charts/rustrial-aws-eks-iam-auth-controller/values.yaml
@@ -29,11 +29,13 @@ podSecurityContext:
   {}
   # fsGroup: 2000
 
-env:
-  - name: RUST_LOG
-    value: debug
-  - name: KUBERNETES_SERVICE_HOST
-    value: kubernetes.default.svc
+env: []
+  # In case you are using an IPv6 cluster, you might need to to explicitly set KUBERNETES_SERVICE_HOST
+  # like shown below to work around a bug in kube-rs.
+  #
+  #- name: KUBERNETES_SERVICE_HOST
+  #  value: kubernetes.default.svc
+
 
 securityContext:
   capabilities:

--- a/charts/rustrial-aws-eks-iam-auth-controller/values.yaml
+++ b/charts/rustrial-aws-eks-iam-auth-controller/values.yaml
@@ -29,6 +29,12 @@ podSecurityContext:
   {}
   # fsGroup: 2000
 
+env:
+  - name: RUST_LOG
+    value: debug
+  - name: KUBERNETES_SERVICE_HOST
+    value: kubernetes.default.svc
+
 securityContext:
   capabilities:
     drop:

--- a/charts/rustrial-aws-eks-iam-auth-controller/values.yaml
+++ b/charts/rustrial-aws-eks-iam-auth-controller/values.yaml
@@ -29,7 +29,9 @@ podSecurityContext:
   {}
   # fsGroup: 2000
 
-env: []
+env:
+  - name: RUST_LOG
+    value: debug
   # In case you are using an IPv6 cluster, you might need to to explicitly set KUBERNETES_SERVICE_HOST
   # like shown below to work around a bug in kube-rs.
   #


### PR DESCRIPTION
The upstream library kube-rs uses an old way of connection to the K8s API, which in their implementation breaks on IPv6 clusters due to wrong URL formatting. This forces the lib to use the proper service, which works on IPv6 clusters as well. The hint towards this solution is from kube-rs/kube-rs#587 - the fix they implemented there is specific to using the rustls feature, which is not in use in this project. But the workaround works regardless.

I also made the env variables configure as a Helm value, in case somebody else needs to change something there in the future. Currently we've applied this fix with kustomize, but having it directly in the chart would let us get rid of that complexity. Plus, others can benefit as well. :)