### PR TITLE
fix: add services and endpoints rbac

### DIFF
--- a/charts/rustrial-aws-eks-iam-auth-controller/templates/serviceaccount.yaml
+++ b/charts/rustrial-aws-eks-iam-auth-controller/templates/serviceaccount.yaml
@@ -26,6 +26,9 @@ rules:
   resources: ["configmaps"]
   resourceNames: ["aws-auth"]
   verbs: ["list", "get", "watch", "create", "delete", "patch"]
+- apiGroups: [""]
+  resources: ["endpoints", "services"]
+  verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Changelog
- Adds endpoints and services readonly

## Description
When implementing I was getting ERRORs like this:

```
[2023-05-01T15:36:40Z DEBUG tower::buffer::worker] service.ready=true message=processing request
[2023-05-01T15:36:40Z DEBUG kube_client::client::builder] HTTP; http.method=PATCH http.url=https://kubernetes.default.svc/api/v1/namespaces/kube-system/configmaps/aws-auth?&force=true&fieldManager=aws-eks-iam-auth-controller.rustrial.org otel.name="patch" otel.kind="client"
[2023-05-01T15:36:40Z DEBUG kube_client::client::builder] requesting
[2023-05-01T15:36:40Z DEBUG hyper::client::connect::dns] resolving host="kubernetes.default.svc"
[2023-05-01T15:36:45Z DEBUG kube_client::client::builder] HTTP; otel.status_code="ERROR"
[2023-05-01T15:36:45Z ERROR kube_client::client::builder] failed with error error trying to connect: dns error: failed to lookup address information: Try again
[2023-05-01T15:36:45Z WARN  rustrial_aws_eks_iam_auth_controller] reconcile failed: reconciler for object IAMIdentityMapping.v1alpha1.iamauthenticator.k8s.aws/ec2-nodes failed
```

After patching in endpoints and services the logs cleared up:

```
[2023-05-01T15:56:21Z DEBUG tower::buffer::worker] service.ready=true message=processing request
[2023-05-01T15:56:21Z DEBUG kube_client::client::builder] HTTP; http.method=GET http.url=https://kubernetes.default.svc/api/v1/namespaces/kube-system/configmaps/aws-auth otel.name="get" otel.kind="client"
[2023-05-01T15:56:21Z DEBUG kube_client::client::builder] requesting
[2023-05-01T15:56:21Z DEBUG hyper::client::pool] reuse idle connection for ("https", kubernetes.default.svc)
[2023-05-01T15:56:21Z DEBUG hyper::proto::h1::io] flushed 1370 bytes
[2023-05-01T15:56:21Z DEBUG hyper::proto::h1::io] parsed 7 headers
[2023-05-01T15:56:21Z DEBUG hyper::proto::h1::conn] incoming body is content-length (1725 bytes)
[2023-05-01T15:56:21Z DEBUG hyper::proto::h1::conn] incoming body completed
[2023-05-01T15:56:21Z DEBUG hyper::client::pool] pooling idle connection for ("https", kubernetes.default.svc)
[2023-05-01T15:56:21Z DEBUG kube_client::client::builder] HTTP; http.status_code=200
```